### PR TITLE
fix: Match CI to local.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,18 +22,13 @@ jobs:
           scope: '@garotm'
 
       - name: Install dependencies
-        run: npm ci
-      
-      - name: Install xvfb
-        run: sudo apt-get install -y xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          npm ci
       
       - name: Run tests
-        run: xvfb-run -a npm test
-      
-      - name: Create VSIX package
-        run: |
-          npm install -g @vscode/vsce
-          vsce package
+        run: ../scripts/ci.sh
       
       - name: Publish to GitHub Packages
         run: npm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,13 @@ jobs:
           scope: '@garotm'
 
       - name: Install dependencies
-        run: npm ci
-      
-      - name: Install xvfb
-        run: sudo apt-get install -y xvfb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          npm ci
       
       - name: Run tests
-        run: xvfb-run -a npm test
+        run: ../scripts/ci.sh
       
       - name: Create VSIX package
         run: |

--- a/vscode-extension/src/test/runTest/index.ts
+++ b/vscode-extension/src/test/runTest/index.ts
@@ -39,7 +39,10 @@ async function main(): Promise<void> {
                 '--disable-extensions',
                 '--disable-telemetry',
                 '--user-data-dir=' + path.join(os.tmpdir(), 'vscode-test-userdata'),
-                '--no-sandbox'
+                '--no-sandbox',
+                '--disable-gpu',
+                '--disable-dev-shm-usage',
+                '--force-device-scale-factor=1'
             ]
         });
     } catch (err) {


### PR DESCRIPTION
# Summary
Make the test environment match precisely by modifying the GitHub Actions workflow to use the same approach as the CI script.

1. Both workflows now use `scripts/ci.sh` directly, which ensures:
   - Exact same test environment setup as local
   - Same xvfb configuration
   - Same build and test sequence
2. Removed redundant steps since they're handled by the CI script
3. Maintained proper working directory configuration

This should make the CI environment match your local testing environment exactly. The CI script already handles xvfb setup and test execution in the same way across all environments.
