### PR TITLE
fix: new workflow logic.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,15 @@
 name: Publish Package
 
 on:
-  release:
-    types: [created]
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -15,16 +18,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-          cache: 'npm'
-          cache-dependency-path: vscode-extension/package-lock.json
           registry-url: 'https://npm.pkg.github.com'
           scope: '@garotm'
       
-      - name: Make CI script executable
-        run: chmod +x scripts/ci.sh
-      
-      - name: Run CI checks
-        run: ./scripts/ci.sh
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifacts
+          path: vscode-extension/out/
       
       - name: Configure npm for publishing
         working-directory: ./vscode-extension
@@ -32,10 +33,19 @@ jobs:
           echo "@garotm:registry=https://npm.pkg.github.com" > .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       
-      - name: Publish to GitHub Packages
+      - name: Prepare and publish package
         working-directory: ./vscode-extension
         run: |
-          npm ci
-          npm publish --access public
+          # Save original package.json
+          cp package.json package.json.bak
+          
+          # Modify package.json for npm publish
+          jq '.name = "@garotm/cursor-rules-dynamic" | del(.publishConfig.name)' package.json > temp.json && mv temp.json package.json
+          
+          # Publish using existing build
+          npm publish --access public --ignore-scripts
+          
+          # Restore original package.json
+          mv package.json.bak package.json
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,10 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./vscode-extension/cursor-rules-dynamic-1.0.0.vsix
           asset_name: cursor-rules-dynamic-1.0.0.vsix
-          asset_content_type: application/octet-stream 
+          asset_content_type: application/octet-stream
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: vscode-extension/out/ 

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -10,7 +10,7 @@
     },
     "publishConfig": {
         "registry": "https://npm.pkg.github.com",
-        "name": "@garotm/cursor-rules-dynamic"
+        "name": "cursor-rules-dynamic"
     },
     "engines": {
         "vscode": "^1.96.0",


### PR DESCRIPTION
# Modify the workflow structure

## Steps
1. Have the release workflow create the build artifacts
2. Have the publish workflow use those artifacts

### Key changes
1. Release workflow now:
   - Builds everything
   - Creates the VSIX
   - Uploads the build artifacts

2. Publish workflow now:
   - Triggers after release workflow completes
   - Downloads the existing build artifacts
   - Uses `--ignore-scripts` to skip rebuilding
   - Only handles the npm package publishing

### This approach
- Eliminates duplicate build steps
- Ensures consistency between VSIX and npm package
- Makes the process more efficient

The publish workflow will now only run after a successful release, using the same built code that went into the VSIX package.
