### PR TITLE
fix: subtle workflow logic changes.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,13 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
           scope: '@garotm'
       
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
+      - name: Download artifacts from release workflow
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: vscode-extension/out/
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
       
       - name: Configure npm for publishing
         working-directory: ./vscode-extension
@@ -41,6 +43,9 @@ jobs:
           
           # Modify package.json for npm publish
           jq '.name = "@garotm/cursor-rules-dynamic" | del(.publishConfig.name)' package.json > temp.json && mv temp.json package.json
+          
+          # Install dependencies without running scripts
+          npm ci --ignore-scripts
           
           # Publish using existing build
           npm publish --access public --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           asset_content_type: application/octet-stream
       
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: vscode-extension/out/ 


### PR DESCRIPTION
# Workflow Logic Changes

The problem is that the publish workflow can't access the artifacts from the release workflow because they're in different workflow runs. When using `workflow_run` trigger, we need to specify the workflow run ID to download artifacts from.


## Key changes
1. Added `github-token` and `run-id` to the download-artifact step
   - `run-id` is set to the ID of the release workflow that triggered this workflow
   - This allows access to artifacts from the triggering workflow

2. Added `npm ci --ignore-scripts` before publishing
   - This ensures all dependencies are installed
   - The `--ignore-scripts` flag prevents rebuilding

3. Renamed the step for clarity

The release workflow successfully uploaded the artifacts, and now the publish workflow should be able to access them correctly using the workflow run ID from the triggering release workflow.